### PR TITLE
Add Storm Peak support, more pmtable sizes and various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/
 scripts/__pycache__/
 scripts/pm_dumps/
+userspace/monitor_cpu
 *.o
 *.ko
 *.cmd

--- a/README.md
+++ b/README.md
@@ -32,12 +32,23 @@ The following processor code names are supported:
 - [Naples](https://en.wikichip.org/wiki/amd/cores/naples)
 - [Lucienne](https://en.wikichip.org/wiki/amd/cores/lucienne)
 - [Phoenix](https://en.wikichip.org/wiki/amd/cores/phoenix)
+- [Strix Point](https://en.wikichip.org/wiki/amd/cores/strix_point)
+- [Granite Ridge](https://en.wikichip.org/wiki/amd/cores/granite_ridge)
+- [Hawk Point](https://en.wikichip.org/wiki/amd/cores/hawk_point)
+- [Storm Peak](https://en.wikichip.org/wiki/amd/cores/storm_peak)
 
 In addition, for the following models, the power metrics/monitoring (PM) table (seen in screenshot)
 can also be accessed:
 
+- Granite Ridge ( Ryzen 9000 Desktop Series )
+- Strix Point ( Ryzen AI 300 )
+- Hawk Point ( Ryzen 8000 Mobile Series )
+- Phoenix ( Ryzen 8000 APU Series )
+- Storm Peak ( ThreadRipper 7000 Workstation Series )
 - Raphael ( Ryzen 7000 Desktop Series )
+- Chagall ( ThreadRipper 5000 Workstation Series )
 - Vermeer ( Ryzen 5000 Desktop Series )
+- Castle Peak ( ThreadRipper 3000 Workstation Series )
 - Matisse ( Ryzen 3000 Desktop Series )
 - Cezanne ( Ryzen 5000[GE] APU Series )
 - Renoir ( Ryzen 4000[UGHS] APU Series )
@@ -56,7 +67,7 @@ permissions (for obvious reasons) at the root path `/sys/kernel/ryzen_smu_drv`:
 - `mp1_smu_cmd`
 - `hsmp_smu_cmd`
 - `smn`
-- `rsmu_cmd` (Not present on `Rembrandt`, `Vangogh`)
+- `rsmu_cmd` (Not present on `Vangogh`)
 
 For supported PM table models where RSMU is also supported, the following files are additionally
 exposed:
@@ -162,7 +173,7 @@ SMU v46.54.0
 4
 
 # cat /sys/kernel/ryzen_smu_drv/drv_version
-0.1.6
+0.1.7
 
 ```
 
@@ -239,7 +250,15 @@ enumeration:
 | 0Eh | 14      | Cezanne        |
 | 0Fh | 15      | Milan          |
 | 10h | 16      | Dali           |
+| 11h | 17      | Luciene        |
+| 12h | 18      | Naples         |
+| 13h | 19      | Chagall        |
+| 14h | 20      | Raphael        |
 | 15h | 21      | Phoenix        |
+| 16h | 22      | Strix Point    |
+| 17h | 23      | Granite Ridge  |
+| 18h | 24      | Hawk Point     |
+| 19h | 25      | Storm Peak     |
 
 Note: This file returns 2 characters of the 'Decimal' encoded index.
 
@@ -313,36 +332,6 @@ Note: File is a 64 bit word encoded in little-endian binary order.
 On supported platforms, listed in the table below, this indicates the version of the metrics table.
 
 Each version corresponds to a specific table size and layout that differs across processors.
-
-The following table lists the known characteristics per version:
-
-| Hex      | Platform    | Table Size (Hex) |
-|:--------:|:-----------:|:----------------:|
-| 0x1E0004 | Raven Ridge | 0x6AC            |
-| 0x1E0005 | Raven Ridge | 0x6AC            |
-| 0x1E0101 | Raven Ridge | 0x6AC            |
-|          |             |                  |
-| 0x240802 | Matisse     | 0x7E0            |
-| 0x240803 | Matisse     | 0x7E4            |
-| 0x240902 | Matisse     | 0x514            |
-| 0x240903 | Matisse     | 0x518            |
-|          |             |                  |
-| 0x2D0803 | Vermeer     | 0x894            |
-| 0x380804 | Vermeer     | 0x8A4            |
-| 0x380805 | Vermeer     | 0x8F0            |
-| 0x2D0903 | Vermeer     | 0x594            |
-| 0x380904 | Vermeer     | 0x5A4            |
-| 0x380905 | Vermeer     | 0x5D0            |
-|          |             |                  |
-| 0x370000 | Renoir      | 0x794            |
-| 0x370001 | Renoir      | 0x884            |
-| 0x370002 | Renoir      | 0x88C            |
-| 0x370004 | Renoir      | 0x8AC            |
-| 0x370005 | Renoir      | 0x8C8            |
-|          |             |                  |
-| 0x400005 | Cezanne     | 0x944            |
-|          |             |                  |
-| 0x2D0008 | Milan       | 0x1AB0           |
 
 Note: File is a 32 bit word encoded in little-endian binary order.
 

--- a/drv.c
+++ b/drv.c
@@ -21,7 +21,7 @@
 
 MODULE_AUTHOR("Leonardo Gates <leogatesx9r@protonmail.com>");
 MODULE_DESCRIPTION("AMD Ryzen SMU Command Driver");
-MODULE_VERSION("0.1.6");
+MODULE_VERSION("0.1.7");
 MODULE_LICENSE("GPL");
 
 #define MSEC_TO_NSEC(x)                    (x * 1000000)

--- a/lib/libsmu.c
+++ b/lib/libsmu.c
@@ -470,8 +470,12 @@ const char* smu_codename_to_str(smu_obj_t* obj) {
             return "Naples";
         case CODENAME_PHOENIX:
             return "Phoenix";
+        case CODENAME_STRIXPOINT:
+            return "Strix Point";
         case CODENAME_HAWKPOINT:
             return "Hawk Point";
+        case CODENAME_STORMPEAK:
+            return "Storm Peak";
         default:
             return "Undefined";
     }

--- a/lib/libsmu.h
+++ b/lib/libsmu.h
@@ -24,7 +24,7 @@
 #include <pthread.h>
 
 /* Version the loaded driver must use to be compatible. */
-#define LIBSMU_SUPPORTED_DRIVER_VERSION                    "0.1.6"
+#define LIBSMU_SUPPORTED_DRIVER_VERSION                    "0.1.7"
 
 /**
  * SMU Mailbox Target
@@ -86,7 +86,6 @@ typedef enum {
     CODENAME_SUMMITRIDGE,
     CODENAME_PINNACLERIDGE,
     CODENAME_REMBRANDT,
-    CODENAME_RAPHAEL,
     CODENAME_VERMEER,
     CODENAME_VANGOGH,
     CODENAME_CEZANNE,
@@ -95,9 +94,12 @@ typedef enum {
     CODENAME_LUCIENNE,
     CODENAME_NAPLES,
     CODENAME_CHAGALL,
+    CODENAME_RAPHAEL,
     CODENAME_PHOENIX,
+    CODENAME_STRIXPOINT,
     CODENAME_GRANITERIDGE,
     CODENAME_HAWKPOINT,
+    CODENAME_STORMPEAK,
     CODENAME_COUNT
 } smu_processor_codename;
 

--- a/smu.h
+++ b/smu.h
@@ -86,9 +86,10 @@ enum smu_processor_codename {
     CODENAME_CHAGALL,
     CODENAME_RAPHAEL,
     CODENAME_PHOENIX,
-    CODENAME_STRIX,
+    CODENAME_STRIXPOINT,
     CODENAME_GRANITERIDGE,
     CODENAME_HAWKPOINT,
+    CODENAME_STORMPEAK,
     CODENAME_COUNT
 };
 
@@ -198,6 +199,7 @@ enum smu_if_version smu_get_mp1_if_version(void);
  * Returns an smu_return_val indicating the status of the operation.
  */
 enum smu_return_val smu_transfer_table_to_dram(struct pci_dev* dev);
+enum smu_return_val smu_transfer_2nd_table_to_dram(struct pci_dev *dev);
 
 /**
  * For Matisse and Renoir processors, returns a numeric value indicating the format
@@ -213,5 +215,10 @@ enum smu_return_val smu_get_pm_table_version(struct pci_dev* dev, u32* version);
  * Returns an smu_return_val indicating the status of the operation.
  */
 enum smu_return_val smu_read_pm_table(struct pci_dev* dev, unsigned char* dst, size_t* len);
+
+int smu_smn_rw_address(struct pci_dev *dev, u32 address, u32 *value, int write);
+int smu_resolve_cpu_class(struct pci_dev *dev);
+u64 smu_get_dram_base_address(struct pci_dev *dev);
+u32 smu_update_pmtable_size(u32 version);
 
 #endif /* __SMU_H__ */

--- a/userspace/monitor_cpu.c
+++ b/userspace/monitor_cpu.c
@@ -442,7 +442,7 @@ unsigned int get_max_cpu_freq(smu_obj_t* obj) {
         return 0;
 
     memset(&args, 0, sizeof(args));
-    if (smu_send_command(obj, 0x6E, &args, TYPE_RSMU) != SMU_Return_OK)
+    if (smu_send_command(obj, 0x6E, &args, SMU_TYPE_RSMU) != SMU_Return_OK)
         return 0;
 
     return args.args[0];
@@ -458,7 +458,7 @@ const char* get_pbo_scalar(smu_obj_t* obj) {
         return 0;
 
     memset(&args, 0, sizeof(args));
-    if (smu_send_command(obj, 0x6C, &args, TYPE_RSMU) != SMU_Return_OK)
+    if (smu_send_command(obj, 0x6C, &args, SMU_TYPE_RSMU) != SMU_Return_OK)
         return "?";
 
     sprintf(buf, "%.fx", args.args_f[0]);


### PR DESCRIPTION
* Added storm peak codename and support.
* Fixed missing strix in libsmu.h's enum. Also reordered this enum as it as well as the bunch of other enums there should be fully synchronized with the ones in smu.h at all times. Ideally good deal of code there should be unified into a single header to avoid out-of-sync possibility due to duplicated definitions.
* Renamed strix codename to strixpoint as there is also strixhalo which is currently not supported.
* Bumped module/libsmu version due to above.
* Fixed userspace's demo which was broken in recent commit due to renamed smu_mailbox enum's values without providing backward compatibility ones.
* Added userspace/monitor_cpu binary to .gitignore
* Fixed compiler's missing-prototypes warnings.
* Update README.MD to be more up-to-date and removed entire pmtable from there as it was long outdated and contained mistakes.
* Added a bunch of table sizes for various pmtable versions and codenames from RM. While at it also sorted version in human sort order and verified already existing pmtable sizes. As a result changed some as some seems like were just a blind guesses and a couple of RE mistakes. That includes reverted commit #dfcda8f as the reporter in that issue complained about insufficient size on Vermeer (5950x on AGESA 1.2.0.6b) but by mistake it was changed for Renoir instead. I additionally tested with 5950x on AGESAs 1.2.0.A and 1.2.0.E without any issues with original size from RM so full revert for now. Also added comments on the table versions which doesn't exist in RM.