### PR TITLE
Note for Proxmox users

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ cd ryzen_smu
 sudo make dkms-install
 ```
 
+Proxmox users can download linux headers with the package `proxmox-default-headers` instead of `linux-headers-$(uname -r)`
+
 ### Arch Linux
 
 Available on the [AUR](https://aur.archlinux.org/packages/ryzen_smu-dkms-git/).


### PR DESCRIPTION
Proxmox (debian) uses the apt package "proxmox-default-headers" instead of linux-headers. I think it would be useful to add this little bit of documentation in the README so that users having this issue can quickly get to the solution.