### PR TITLE
smu: document verified support for Ryzen AI 9 HX 370 (Strix Point)

### DIFF
--- a/smu.c
+++ b/smu.c
@@ -351,7 +351,7 @@ int smu_resolve_cpu_class(struct pci_dev *dev) {
   // Zen 5
   else if (cpu_family == 0x1a) {
     switch (cpu_model) {
-    case 0x24:
+    case 0x24: // Strix Point (Ryzen AI 9 HX 370, family 0x1A model 0x24)
       g_smu.codename = CODENAME_STRIXPOINT;
       break;
     case 0x44:
@@ -1141,7 +1141,7 @@ u32 smu_update_pmtable_size(u32 version) {
   case CODENAME_STRIXPOINT:
     switch (version) {
     case 0x5D0008:
-    case 0x5D0009: // assuming that Ryzen PRO is the same as the non PRO variant
+    case 0x5D0009: // Ryzen PRO / Ryzen AI 9 HX 370 (Strix Point, verified pm_table_version=0x5D0009, pm_table_size=0xD54)
       g_smu.pm_dram_map_size = 0xD54;
       break;
     case 0x650007: // Ryzen AI 7 350 variant


### PR DESCRIPTION
## Description
Document verified hardware support for AMD Ryzen AI 9 HX 370 (Strix Point, Zen 5).

No functional changes — this PR adds comments to clarify which hardware
has been tested against existing code paths.

## Changes
- `case 0x24`: added comment documenting Ryzen AI 9 HX 370 is resolved
  via this path to `CODENAME_STRIXPOINT`
- `case 0x5D0009`: updated comment to reflect verified pm_table_version
  and pm_table_size on real hardware (previously assumed from Ryzen PRO)

## Hardware tested
| Field              | Value                        |
|--------------------|------------------------------|
| CPU                | AMD Ryzen AI 9 HX 370        |
| Codename           | Strix Point                  |
| CPUID family       | 0x1A                         |
| CPUID model        | 0x24                         |
| CPUID stepping     | 0x0                          |
| SMU firmware       | 11.93.4.0                    |
| MP1 IF version     | 13                           |
| PM table version   | 0x005D0009                   |
| PM table size      | 0xD54 (3412 bytes, 853 values)|

## Verification
Driver loads and detects correctly:
[ 2498.638400] ryzen_smu: loading version: 0.1.7
[ 2498.638408] ryzen_smu: CPUID: family 0x1A, model 0x24, stepping 0x0, package 0x1
[ 2498.638411] ryzen_smu: Family Codename: Strix Point

PM table reads successfully with all sensors functional (power, thermal,
frequency, voltage). Confirmed `pm_table_version=0x5D0009` and
`pm_table_size=0xD54` match existing `case 0x5D0009` code path —
this is NOT the same as the Ryzen PRO assumption, it is now verified
on consumer Ryzen AI 9 HX 370 hardware.

## Tested on
- OS: Arch Linux
- Kernel: custom build (Clang/LLVM, znver5)
- Driver built manually via `make` and loaded via `insmod`