### PR TITLE
Fixed: test.py script failing preemptively due to formatting

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -156,7 +156,7 @@ def test_get_version():
     if args == False:
         return False
 
-    v_test = "{:d}.{:d}.{:d}\n".format(
+    v_test = "{:d}.{:d}.{:d}".format(
         args[0] >> 16 & 0xFF, args[0] >> 8 & 0xFF, args[0] & 0xFF
     )
 


### PR DESCRIPTION
I ran:
`sudo python test.py`
which output:
`SMU Test: Failed!`

after applying the change it ouputs:
```
Retrieved SMU Version: v76.101.0\nProcessor Code Name: Phoenix  
PM Table: Supported
SMN Offset[0x50200]: 0x40c50af0

Everything seems to be working properly!
```